### PR TITLE
Support macOS 15 and harden helper XPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,14 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  MACOSX_DEPLOYMENT_TARGET: "15.0"
+  MUGSHOT_SWIFT_TARGET: arm64-apple-macosx15.0
+
 jobs:
   build:
     name: Build & test (macOS)
-    runs-on: macos-14
+    runs-on: macos-15
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
@@ -51,18 +55,18 @@ jobs:
 
       - name: Compile menu bar app
         run: |
-          swiftc -O -swift-version 5 -o /tmp/Mugshot \
+          swiftc -O -swift-version 5 -target "$MUGSHOT_SWIFT_TARGET" -o /tmp/Mugshot \
             menubar/Branding.swift menubar/Onboarding.swift \
             menubar/SettingsView.swift menubar/HelperManager.swift \
             helpertool/HelperProtocol.swift menubar/FaceIDApp.swift \
             -framework AppKit -framework SwiftUI \
-            -framework AVFoundation -framework ServiceManagement \
+            -framework AVFoundation -framework ServiceManagement -framework Security \
             -F vendor/sparkle -framework Sparkle \
             -Xlinker -rpath -Xlinker @executable_path/../Frameworks
 
       - name: Compile privileged helper
         run: |
-          swiftc -O -swift-version 5 -o /tmp/MugshotHelper \
+          swiftc -O -swift-version 5 -target "$MUGSHOT_SWIFT_TARGET" -o /tmp/MugshotHelper \
             helpertool/main.swift helpertool/HelperProtocol.swift \
             helpertool/CodesignCheck.swift \
             -framework Foundation -framework Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project are documented here. The format is based on
 
 ## [Unreleased]
 
+### Changed
+
+- Set macOS 15 as the supported baseline across native builds, packaging, CI, and documentation.
+- Reject app bundles containing Mach-O binaries that require a newer macOS release.
+
 ## [1.0.0] - 2026-07-23
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Thanks for your interest! This is a small, fun project, contributions are welcom
 
 ## Dev setup
 
-Requirements: macOS (Apple Silicon), Xcode Command Line Tools, Python 3.12.
+Requirements: macOS 15 or later (Apple Silicon), Xcode Command Line Tools, Python 3.12 or later.
 
 ```bash
 git clone https://github.com/Lorenzo-Coslado/macos-faceid.git

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ recognition fully on your Mac.
 <p>
   <a href="https://github.com/Lorenzo-Coslado/macos-faceid/releases"><img src="https://img.shields.io/github/downloads/Lorenzo-Coslado/macos-faceid/total?label=downloads&color=3ba55d&logo=github&logoColor=white" alt="Downloads" /></a>
   <a href="https://github.com/Lorenzo-Coslado/macos-faceid/actions/workflows/ci.yml"><img src="https://github.com/Lorenzo-Coslado/macos-faceid/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/macOS-13+-1d1d1f?logo=apple" alt="macOS 13+" />
+  <img src="https://img.shields.io/badge/macOS-15+-1d1d1f?logo=apple" alt="macOS 15+" />
   <img src="https://img.shields.io/badge/Apple%20Silicon-1d1d1f" alt="Apple Silicon" />
   <img src="https://img.shields.io/badge/license-MIT-3ba55d" alt="MIT" />
 </p>
@@ -167,7 +167,7 @@ sudo it is never requested.
 <details>
 <summary><b>Which Macs are supported?</b></summary>
 
-Apple Silicon Macs on macOS 13 or later, with any built-in or external webcam.
+Apple Silicon Macs on macOS 15 or later, with any built-in or external webcam.
 </details>
 
 <details>

--- a/appcast.xml
+++ b/appcast.xml
@@ -7,7 +7,8 @@
             <pubDate>Fri, 24 Jul 2026 11:08:44 -0400</pubDate>
             <sparkle:version>2</sparkle:version>
             <sparkle:shortVersionString>1.0.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <!-- v1.0.1 was built with a macOS 26 deployment target. -->
+            <sparkle:minimumSystemVersion>26.0</sparkle:minimumSystemVersion>
             <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <enclosure url="https://github.com/Lorenzo-Coslado/macos-faceid/releases/download/v1.0.1/Mugshot.dmg" length="104922323" type="application/octet-stream" sparkle:edSignature="rNEi9hKo2QKTbJzR3CFMChNzqldvn+0K75BD0dLHNPGHSlbJaeZof0Xlzw39BPQ6U+lISMfQLSy7l5x5c0anCA=="/>
         </item>

--- a/helpertool/CodesignCheck.swift
+++ b/helpertool/CodesignCheck.swift
@@ -13,7 +13,31 @@ enum CodesignCheckError: Error {
 struct CodesignCheck {
 
     public static func codeSigningMatches(pid: pid_t) throws -> Bool {
-        return try self.codeSigningCertificatesForSelf() == self.codeSigningCertificates(forPID: pid)
+        guard let ownCode = try secStaticCodeSelf(),
+              let peerCode = try secStaticCode(forPID: pid),
+              let ownInfo = try secCodeInfo(forStaticCode: ownCode),
+              let peerInfo = try secCodeInfo(forStaticCode: peerCode) else { return false }
+
+        let ownCertificates = certificates(from: ownInfo)
+        let peerCertificates = certificates(from: peerInfo)
+
+        // Une release Developer ID doit conserver exactement la même chaîne de
+        // certificats des deux côtés. Un mélange signed/ad-hoc est toujours refusé.
+        if !ownCertificates.isEmpty || !peerCertificates.isEmpty {
+            return !ownCertificates.isEmpty && ownCertificates == peerCertificates
+        }
+
+        // Les builds locaux ad-hoc n'ont aucun certificat à comparer. On limite
+        // alors le client au binaire principal attendu, dans le même bundle .app
+        // que ce helper, après validation cryptographique des deux Mach-O ci-dessus.
+        guard identifier(from: peerInfo) == "com.lorenzo.Mugshot",
+              let ownExecutable = executableURL(from: ownInfo),
+              let peerExecutable = executableURL(from: peerInfo),
+              ownExecutable.lastPathComponent == "MugshotHelper",
+              peerExecutable.lastPathComponent == "Mugshot",
+              let ownApp = containingAppURL(for: ownExecutable),
+              let peerApp = containingAppURL(for: peerExecutable) else { return false }
+        return ownApp == peerApp
     }
 
     public static func codeSigningCertificatesForSelf() throws -> [SecCertificate] {
@@ -75,9 +99,31 @@ struct CodesignCheck {
     }
 
     private static func codeSigningCertificates(forStaticCode secStaticCode: SecStaticCode) throws -> [SecCertificate] {
-        guard
-            let secCodeInfo = try secCodeInfo(forStaticCode: secStaticCode),
-            let secCertificates = secCodeInfo[kSecCodeInfoCertificates as String] as? [SecCertificate] else { return [] }
-        return secCertificates
+        guard let secCodeInfo = try secCodeInfo(forStaticCode: secStaticCode) else { return [] }
+        return certificates(from: secCodeInfo)
+    }
+
+    private static func certificates(from info: [String: Any]) -> [SecCertificate] {
+        info[kSecCodeInfoCertificates as String] as? [SecCertificate] ?? []
+    }
+
+    private static func identifier(from info: [String: Any]) -> String? {
+        info[kSecCodeInfoIdentifier as String] as? String
+    }
+
+    private static func executableURL(from info: [String: Any]) -> URL? {
+        guard let url = info[kSecCodeInfoMainExecutable as String] as? URL else { return nil }
+        return url.standardizedFileURL.resolvingSymlinksInPath()
+    }
+
+    private static func containingAppURL(for executable: URL) -> URL? {
+        var candidate = executable.deletingLastPathComponent()
+        while candidate.path != "/" {
+            if candidate.pathExtension == "app" {
+                return candidate.standardizedFileURL.resolvingSymlinksInPath()
+            }
+            candidate.deleteLastPathComponent()
+        }
+        return nil
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Installation complète de FaceID en une commande.
-# Prérequis : macOS (Apple Silicon), Xcode Command Line Tools, Python 3.12, webcam.
+# Prérequis : macOS 15+ (Apple Silicon), Xcode Command Line Tools, Python 3.12+, webcam.
 set -euo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/menubar/FaceIDApp.swift
+++ b/menubar/FaceIDApp.swift
@@ -261,6 +261,32 @@ final class AppController: NSObject, NSApplicationDelegate {
 @main
 struct FaceIDMain {
     static func main() {
+        if CommandLine.arguments.contains("--refresh-helper") {
+            switch HelperManager.shared.refreshRegistration() {
+            case .enabled:
+                print("helper enregistré et activé")
+                exit(0)
+            case .needsApproval:
+                print("helper enregistré; approbation requise dans Réglages > Éléments d'ouverture")
+                exit(3)
+            case .failed(let message):
+                fputs("échec de l'enregistrement du helper : \(message)\n", stderr)
+                exit(1)
+            }
+        }
+        if CommandLine.arguments.contains("--probe-helper") {
+            var result: Int32?
+            HelperManager.shared.probe { ok, message in
+                print(message)
+                result = ok ? 0 : 1
+            }
+            let deadline = Date().addingTimeInterval(8)
+            while result == nil && Date() < deadline {
+                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.1))
+            }
+            if result == nil { fputs("helper probe timeout\n", stderr) }
+            exit(result ?? 2)
+        }
         let app = NSApplication.shared
         app.setActivationPolicy(.accessory)
         let controller = AppController()

--- a/menubar/HelperManager.swift
+++ b/menubar/HelperManager.swift
@@ -4,11 +4,11 @@
 import Foundation
 import ServiceManagement
 import AppKit
+import Security
 
 final class HelperManager {
     static let shared = HelperManager()
     private let plistName = "com.lorenzo.Mugshot.Helper.plist"
-    private let teamID = "RQUR2C3YDZ"
     private var service: SMAppService { SMAppService.daemon(plistName: plistName) }
 
     var isEnabled: Bool { service.status == .enabled }
@@ -28,7 +28,11 @@ final class HelperManager {
     enum Reg { case enabled, needsApproval, failed(String) }
 
     private func openApproval() {
-        DispatchQueue.main.async { SMAppService.openSystemSettingsLoginItems() }
+        if Thread.isMainThread {
+            SMAppService.openSystemSettingsLoginItems()
+        } else {
+            DispatchQueue.main.async { SMAppService.openSystemSettingsLoginItems() }
+        }
     }
 
     /// Enregistre le daemon si nécessaire. `.needsApproval` → l'utilisateur doit
@@ -51,6 +55,10 @@ final class HelperManager {
                 default: return .failed("statut inattendu : \(service.status.rawValue)")
                 }
             } catch {
+                if service.status == .requiresApproval {
+                    openApproval()
+                    return .needsApproval
+                }
                 return .failed(error.localizedDescription)
             }
         }
@@ -58,13 +66,71 @@ final class HelperManager {
 
     func unregister() { try? service.unregister() }
 
+    /// Réenregistre explicitement le daemon après remplacement d'un build local
+    /// ad-hoc (son cdhash change et macOS invalide alors l'ancien enregistrement).
+    func refreshRegistration() -> Reg {
+        do {
+            if service.status != .notRegistered {
+                try service.unregister()
+            }
+            try service.register()
+            switch service.status {
+            case .enabled:
+                return .enabled
+            case .requiresApproval:
+                openApproval()
+                return .needsApproval
+            default:
+                return .failed("statut inattendu : \(service.status.rawValue)")
+            }
+        } catch {
+            if service.status == .requiresApproval {
+                openApproval()
+                return .needsApproval
+            }
+            return .failed(error.localizedDescription)
+        }
+    }
+
     // MARK: XPC
+
+    /// Construit une exigence adaptée à la signature réellement installée.
+    /// - Developer ID : même Team ID que l'app.
+    /// - build local ad-hoc : cdhash exact du helper embarqué.
+    private func helperCodeSigningRequirement() -> String? {
+        var selfCode: SecCode?
+        guard SecCodeCopySelf([], &selfCode) == errSecSuccess, let selfCode else { return nil }
+        var selfStaticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(selfCode, [], &selfStaticCode) == errSecSuccess,
+              let selfStaticCode else { return nil }
+
+        var selfInfoRef: CFDictionary?
+        guard SecCodeCopySigningInformation(selfStaticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &selfInfoRef) == errSecSuccess,
+              let selfInfo = selfInfoRef as? [String: Any] else { return nil }
+
+        if let teamID = selfInfo[kSecCodeInfoTeamIdentifier as String] as? String,
+           !teamID.isEmpty {
+            return "anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\""
+        }
+
+        var helperCode: SecStaticCode?
+        guard SecStaticCodeCreateWithPath(URL(fileURLWithPath: helperPath) as CFURL, [], &helperCode) == errSecSuccess,
+              let helperCode else { return nil }
+        var helperInfoRef: CFDictionary?
+        guard SecCodeCopySigningInformation(helperCode, SecCSFlags(rawValue: kSecCSSigningInformation), &helperInfoRef) == errSecSuccess,
+              let helperInfo = helperInfoRef as? [String: Any],
+              let cdhash = helperInfo[kSecCodeInfoUnique as String] as? Data else { return nil }
+        return "cdhash H\"\(cdhash.map { String(format: "%02x", $0) }.joined())\""
+    }
 
     private func newConnection() -> NSXPCConnection {
         let c = NSXPCConnection(machServiceName: kMugshotHelperMachService, options: .privileged)
         c.remoteObjectInterface = NSXPCInterface(with: MugshotHelperProtocol.self)
-        // N'accepte que le daemon signé par notre équipe Developer ID.
-        try? c.setCodeSigningRequirement("anchor apple generic and certificate leaf[subject.OU] = \"\(teamID)\"")
+        if let requirement = helperCodeSigningRequirement() {
+            c.setCodeSigningRequirement(requirement)
+        } else {
+            NSLog("Mugshot: impossible de construire l'exigence de signature du helper; validation côté helper uniquement")
+        }
         c.resume()
         return c
     }
@@ -87,5 +153,30 @@ final class HelperManager {
     }
     func disableSudo(_ done: @escaping (Bool, String) -> Void) {
         call({ $0.disableSudo(withReply: $1) }, done)
+    }
+
+    /// Teste uniquement le canal XPC; ne modifie pas la configuration PAM.
+    func probe(_ done: @escaping (Bool, String) -> Void) {
+        let c = newConnection()
+        let proxy = c.remoteObjectProxyWithErrorHandler { err in
+            DispatchQueue.main.async {
+                c.invalidate()
+                done(false, "Connexion au helper : \(err.localizedDescription)")
+            }
+        } as? MugshotHelperProtocol
+        guard let proxy else {
+            c.invalidate()
+            done(false, "Proxy XPC indisponible.")
+            return
+        }
+        proxy.version { version in
+            DispatchQueue.main.async {
+                c.invalidate()
+                done(version == kMugshotHelperVersion,
+                     version == kMugshotHelperVersion
+                        ? "helper v\(version) joignable"
+                        : "version helper incompatible : \(version)")
+            }
+        }
     }
 }

--- a/pam/Makefile
+++ b/pam/Makefile
@@ -1,6 +1,8 @@
 SDK   := $(shell xcrun --show-sdk-path)
 CC    := clang
-CFLAGS  := -Wall -Wextra -O2 -isysroot $(SDK)
+MACOSX_DEPLOYMENT_TARGET ?= 15.0
+TARGET  := arm64-apple-macosx$(MACOSX_DEPLOYMENT_TARGET)
+CFLAGS  := -Wall -Wextra -O2 -isysroot $(SDK) -target $(TARGET)
 LDFLAGS := -bundle -lpam
 
 pam_faceid.so: pam_faceid.c

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 numpy>=1.26
 opencv-contrib-python>=4.9,<5
+pyinstaller>=6.21,<7

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$HERE/scripts/macos-target.sh"
 APP="$HERE/build/Mugshot.app"
 BUNDLE_ID="com.lorenzo.Mugshot"
 DEST="/Applications/Mugshot.app"
@@ -28,7 +29,10 @@ for sz in 16 32 128 256 512; do
   sips -z $((sz*2)) $((sz*2)) "$SRC" --out "$ICONSET/icon_${sz}x${sz}@2x.png" >/dev/null
 done
 cp "$SRC" "$ICONSET/icon_512x512@2x.png"
-iconutil -c icns "$ICONSET" -o "$HERE/assets/Mugshot.icns"
+if ! iconutil -c icns "$ICONSET" -o "$HERE/assets/Mugshot.icns"; then
+  [ -f "$HERE/assets/Mugshot.icns" ] || exit 1
+  echo "Avertissement: iconutil a échoué; réutilisation de assets/Mugshot.icns" >&2
+fi
 
 echo "== Assemblage du bundle =="
 rm -rf "$APP"
@@ -48,7 +52,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleShortVersionString</key> <string>1.0</string>
   <key>CFBundleVersion</key>         <string>1</string>
   <key>LSUIElement</key>             <true/>
-  <key>LSMinimumSystemVersion</key>  <string>13.0</string>
+  <key>LSMinimumSystemVersion</key>  <string>${MACOSX_DEPLOYMENT_TARGET}</string>
   <key>SUFeedURL</key>               <string>https://raw.githubusercontent.com/Lorenzo-Coslado/macos-faceid/main/appcast.xml</string>
   <key>SUPublicEDKey</key>           <string>MYs0iwYg/b5lDERYBHVBBiIw8R2awqExOluwOfZlp0w=</string>
   <key>SUEnableAutomaticChecks</key> <true/>
@@ -86,6 +90,7 @@ cp -R "$HERE"/i18n/*.lproj "$APP/Contents/Resources/"
 
 echo "== Compilation de l'app =="
 swiftc -O -swift-version 5 \
+  -target "$MUGSHOT_SWIFT_TARGET" \
   -o "$APP/Contents/MacOS/Mugshot" \
   "$HERE/menubar/Branding.swift" \
   "$HERE/menubar/Onboarding.swift" \
@@ -93,12 +98,13 @@ swiftc -O -swift-version 5 \
   "$HERE/menubar/HelperManager.swift" \
   "$HERE/helpertool/HelperProtocol.swift" \
   "$HERE/menubar/FaceIDApp.swift" \
-  -framework AppKit -framework SwiftUI -framework AVFoundation -framework ServiceManagement \
+  -framework AppKit -framework SwiftUI -framework AVFoundation -framework ServiceManagement -framework Security \
   -F "$HERE/vendor/sparkle" -framework Sparkle \
   -Xlinker -rpath -Xlinker @executable_path/../Frameworks
 
 echo "== Compilation du daemon privilégié (MugshotHelper) =="
 swiftc -O -swift-version 5 \
+  -target "$MUGSHOT_SWIFT_TARGET" \
   -o "$APP/Contents/MacOS/MugshotHelper" \
   "$HERE/helpertool/main.swift" \
   "$HERE/helpertool/HelperProtocol.swift" \
@@ -109,6 +115,7 @@ echo "== Scripts exécutables =="
 chmod +x "$HERE"/scripts/*.sh 2>/dev/null || true
 
 echo "== Signature ad-hoc =="
+bash "$HERE/scripts/check-macos-compat.sh" "$APP"
 codesign --force --deep --sign - "$APP"
 
 echo "== Installation dans /Applications =="

--- a/scripts/build-helpers.sh
+++ b/scripts/build-helpers.sh
@@ -3,20 +3,21 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$HERE/scripts/macos-target.sh"
 SRC="$HERE/helpers/touchid-helper.swift"
 OUT="$HERE/helpers/touchid-helper"
 
 echo "== Compilation touchid-helper =="
-swiftc -O -o "$OUT" "$SRC" -framework LocalAuthentication
+swiftc -O -target "$MUGSHOT_SWIFT_TARGET" -o "$OUT" "$SRC" -framework LocalAuthentication
 echo "   -> $OUT"
 
 echo "== Vérification de la disponibilité Touch ID =="
 "$OUT" --check || echo "   (Touch ID indisponible sur cette machine ?)"
 
 echo "== Compilation auth-modal (panneau natif) =="
-swiftc -O -o "$HERE/helpers/auth-modal" "$HERE/helpers/auth-modal.swift" -framework AppKit
+swiftc -O -target "$MUGSHOT_SWIFT_TARGET" -o "$HERE/helpers/auth-modal" "$HERE/helpers/auth-modal.swift" -framework AppKit
 echo "   -> $HERE/helpers/auth-modal"
 
 echo "== Compilation faceid-hud (capsule Dynamic Island) =="
-swiftc -O -o "$HERE/helpers/faceid-hud" "$HERE/helpers/faceid-hud.swift" -framework AppKit -framework QuartzCore
+swiftc -O -target "$MUGSHOT_SWIFT_TARGET" -o "$HERE/helpers/faceid-hud" "$HERE/helpers/faceid-hud.swift" -framework AppKit -framework QuartzCore
 echo "   -> $HERE/helpers/faceid-hud"

--- a/scripts/build-standalone.sh
+++ b/scripts/build-standalone.sh
@@ -5,14 +5,16 @@
 set -euo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$HERE/scripts/macos-target.sh"
 cd "$HERE"
 PY="$HERE/.venv/bin/python"
+export PYINSTALLER_CONFIG_DIR="${PYINSTALLER_CONFIG_DIR:-/tmp/mugshot-pyinstaller}"
 APP="$HERE/dist/Mugshot.app"
 RES="$APP/Contents/Resources"
 BUNDLE_ID="com.lorenzo.Mugshot"
 MARKETING_VERSION="${MARKETING_VERSION:-1.0}"   # ex: 1.0.1 (surchargé par release.sh)
 BUILD_VERSION="${BUILD_VERSION:-1}"             # entier monotone (Sparkle compare ceci)
-MODELS="$HOME/Library/Application Support/faceid/models"
+MODELS="${FACEID_MODELS_DIR:-$HOME/Library/Application Support/faceid/models}"
 
 echo "══ 1/6  Prérequis (modèles, helpers, module PAM, assets, i18n) ══"
 [ -f "$MODELS/face_recognition_sface_2021dec.onnx" ] || bash scripts/download-models.sh
@@ -29,7 +31,10 @@ for sz in 16 32 128 256 512; do
   sips -z $((sz*2)) $((sz*2)) "$SRC" --out "$ICONSET/icon_${sz}x${sz}@2x.png" >/dev/null
 done
 cp "$SRC" "$ICONSET/icon_512x512@2x.png"
-iconutil -c icns "$ICONSET" -o "$HERE/assets/Mugshot.icns"
+if ! iconutil -c icns "$ICONSET" -o "$HERE/assets/Mugshot.icns"; then
+  [ -f "$HERE/assets/Mugshot.icns" ] || exit 1
+  echo "Avertissement: iconutil a échoué; réutilisation de assets/Mugshot.icns" >&2
+fi
 
 echo "══ 2/6  Moteur Python autonome (PyInstaller) ══"
 rm -rf packaging/dist packaging/build packaging/*.spec
@@ -40,14 +45,14 @@ rm -rf packaging/dist packaging/build packaging/*.spec
 echo "══ 3/6  Compilation de l'app Swift ══"
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$RES"
-swiftc -O -swift-version 5 -o "$APP/Contents/MacOS/Mugshot" \
+swiftc -O -swift-version 5 -target "$MUGSHOT_SWIFT_TARGET" -o "$APP/Contents/MacOS/Mugshot" \
   menubar/Branding.swift menubar/Onboarding.swift menubar/SettingsView.swift \
   menubar/HelperManager.swift helpertool/HelperProtocol.swift menubar/FaceIDApp.swift \
-  -framework AppKit -framework SwiftUI -framework AVFoundation -framework ServiceManagement \
+  -framework AppKit -framework SwiftUI -framework AVFoundation -framework ServiceManagement -framework Security \
   -F "$HERE/vendor/sparkle" -framework Sparkle \
   -Xlinker -rpath -Xlinker @executable_path/../Frameworks
 # daemon privilégié root (SMAppService + XPC)
-swiftc -O -swift-version 5 -o "$APP/Contents/MacOS/MugshotHelper" \
+swiftc -O -swift-version 5 -target "$MUGSHOT_SWIFT_TARGET" -o "$APP/Contents/MacOS/MugshotHelper" \
   helpertool/main.swift helpertool/HelperProtocol.swift helpertool/CodesignCheck.swift \
   -framework Foundation -framework Security
 
@@ -66,7 +71,7 @@ cat > "$APP/Contents/Info.plist" <<PLIST
   <key>CFBundleShortVersionString</key> <string>${MARKETING_VERSION}</string>
   <key>CFBundleVersion</key>         <string>${BUILD_VERSION}</string>
   <key>LSUIElement</key>             <true/>
-  <key>LSMinimumSystemVersion</key>  <string>13.0</string>
+  <key>LSMinimumSystemVersion</key>  <string>${MACOSX_DEPLOYMENT_TARGET}</string>
   <key>SUFeedURL</key>               <string>https://raw.githubusercontent.com/Lorenzo-Coslado/macos-faceid/main/appcast.xml</string>
   <key>SUPublicEDKey</key>           <string>MYs0iwYg/b5lDERYBHVBBiIw8R2awqExOluwOfZlp0w=</string>
   <key>SUEnableAutomaticChecks</key> <true/>
@@ -87,13 +92,15 @@ cp "$HERE/assets/menubar-icon.png" "$RES/menubar-icon.png"
 cp -R "$HERE/packaging/dist/faceid" "$RES/faceid"                 # moteur Python autonome
 mkdir -p "$RES/helpers" "$RES/assets" "$RES/models" "$RES/pam" "$RES/scripts"
 cp "$HERE/helpers/touchid-helper" "$HERE/helpers/auth-modal" "$HERE/helpers/faceid-hud" "$RES/helpers/"
-cp "$HERE/assets/faceid-icon.png" "$HERE/assets/faceid-icon.icns" "$RES/assets/"
+cp "$HERE/assets/faceid-icon.png" "$RES/assets/"
+cp "$HERE/assets/FaceID.icns" "$RES/assets/faceid-icon.icns"
 cp "$MODELS/"*.onnx "$RES/models/"
 cp "$HERE/pam/pam_faceid.so" "$RES/pam/"
 cp "$HERE/scripts/pam-install-root.sh" "$HERE/scripts/pam-uninstall-root.sh" "$RES/scripts/"
 cp -R "$HERE"/i18n/*.lproj "$RES/"
 
 echo "══ 6/6  Signature ad-hoc (test local) ══"
+bash "$HERE/scripts/check-macos-compat.sh" "$APP"
 codesign --force --deep --sign - "$APP" 2>/dev/null
 
 SIZE=$(du -sh "$APP" | cut -f1)

--- a/scripts/check-macos-compat.sh
+++ b/scripts/check-macos-compat.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Fail when a Mach-O inside an app requires a newer macOS than our baseline.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$HERE/scripts/macos-target.sh"
+
+APP="${1:?usage: check-macos-compat.sh /path/to/App.app}"
+[ -d "$APP" ] || { echo "app introuvable : $APP" >&2; exit 2; }
+
+version_gt() {
+  awk -v lhs="$1" -v rhs="$2" 'BEGIN {
+    split(lhs, a, "."); split(rhs, b, ".")
+    for (i = 1; i <= 3; i++) {
+      av = (a[i] == "" ? 0 : a[i]) + 0
+      bv = (b[i] == "" ? 0 : b[i]) + 0
+      if (av > bv) exit 0
+      if (av < bv) exit 1
+    }
+    exit 1
+  }'
+}
+
+failed=0
+count=0
+while IFS= read -r -d '' file_path; do
+  if ! file -b "$file_path" 2>/dev/null | grep -q 'Mach-O'; then
+    continue
+  fi
+  count=$((count + 1))
+  while IFS= read -r minos; do
+    [ -n "$minos" ] || continue
+    if version_gt "$minos" "$MACOSX_DEPLOYMENT_TARGET"; then
+      echo "incompatible: $file_path requires macOS $minos (baseline $MACOSX_DEPLOYMENT_TARGET)" >&2
+      failed=1
+    fi
+  done < <(xcrun vtool -show-build "$file_path" 2>/dev/null | awk '$1 == "minos" { print $2 }')
+done < <(find "$APP" -type f -print0)
+
+[ "$count" -gt 0 ] || { echo "aucun Mach-O trouvé dans $APP" >&2; exit 2; }
+[ "$failed" -eq 0 ] || exit 1
+echo "Compatibility OK: $count Mach-O file(s), macOS <= $MACOSX_DEPLOYMENT_TARGET"

--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -2,7 +2,7 @@
 # Télécharge les modèles ONNX (YuNet + SFace) depuis OpenCV Zoo.
 set -euo pipefail
 
-DEST="${HOME}/Library/Application Support/faceid/models"
+DEST="${FACEID_MODELS_DIR:-${HOME}/Library/Application Support/faceid/models}"
 mkdir -p "$DEST"
 
 BASE="https://github.com/opencv/opencv_zoo/raw/main/models"

--- a/scripts/macos-target.sh
+++ b/scripts/macos-target.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Shared deployment target for every native component in the app bundle.
+# Keep this in sync with Info.plist, appcast.xml, README, and CI.
+: "${MACOSX_DEPLOYMENT_TARGET:=15.0}"
+: "${MUGSHOT_SWIFT_TARGET:=arm64-apple-macosx${MACOSX_DEPLOYMENT_TARGET}}"
+
+export MACOSX_DEPLOYMENT_TARGET
+export MUGSHOT_SWIFT_TARGET


### PR DESCRIPTION
## Summary

- set the official deployment baseline to macOS 15 across Swift, PAM, packaging, installer metadata, documentation, and CI
- add a Mach-O compatibility audit that fails when any bundled binary requires a newer macOS release
- make standalone packaging reproducible with explicit model/cache paths and current PyInstaller support
- replace the hard-coded helper Team ID with runtime signing requirements
- support local ad-hoc builds securely by pinning the helper cdhash and restricting helper clients to the expected executable inside the same app bundle
- add read-only helper probe and local registration-refresh diagnostics

## Why

The existing source could compile against the host SDK and silently inherit a newer minimum OS. In addition, local ad-hoc builds could register the privileged helper but the app rejected it because the XPC requirement was hard-coded to the original developer Team ID.

## Impact

The project now declares macOS 15 as its compatibility floor, validates every bundled Mach-O against that floor, and works with both Developer ID releases and local ad-hoc builds without weakening the privileged helper boundary.

## Validation

- complete standalone build succeeded on macOS 15.7.7
- 171 bundled Mach-O files passed the `minos <= 15.0` audit
- deep code-signature verification passed
- installed app and privileged helper launched successfully
- positive XPC probe returned `helper v1 joignable`
- an external ad-hoc client was rejected by the helper
- plist lint and staged diff checks passed

## Notes

The existing `NSUserNotification` deprecation warnings remain unchanged and are outside this compatibility change.